### PR TITLE
Added styling to grayscale row images and adjusted saturation when mouse hovers over images

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -190,10 +190,11 @@ main {
 
 .row img {
     border: 2px solid var(--light-blue-text-color);
+    filter: grayscale(50%);
 }
 
 .row img:hover,
 .project-sections img:hover {
-    filter: saturate(120%)
+    filter: saturate(100%)
 }
 


### PR DESCRIPTION
`filter:grayscale(50%)` was added to images within the **work** section. When a user hovers over the image, a saturation filter is applied to the image to contrast the default, viewing state. 