### PR TITLE
Added media query logic to structure page for a vertical orientation on devices with a width at or narrower than the width of an iPad Mini screen

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -220,3 +220,37 @@ main {
     filter: saturate(100%)
 }
 
+
+@media screen and (max-width: 768px) { /* This size was chosen as it is the width of a smaller tablet (iPad Mini)*/
+
+    /* Place headers elements as block/stack */
+
+    header {
+        display: flex;
+        flex-direction: column;
+        flex-wrap: wrap;
+    }
+
+    nav ul {
+        display: flex;
+        flex-direction: column;
+        flex-wrap: wrap;
+    }
+
+  
+    /* Change to a vertical stack of the containers and their children elements */
+    .row {
+        display: flex;
+        flex-direction: column;
+        flex-wrap: wrap;
+    }
+    
+    /* Removes the border on the right of the h2 container and places one on the bottom */
+    .row h2 {
+    border-right: 0cap;
+    border-bottom-color: var(--dark-blue-text-color);
+    border-bottom: 2px solid;
+    padding: 2%;
+    font-size: 35px;
+    }
+}


### PR DESCRIPTION
Changes were made to the `header`, the `nav ul` within the header, the `.row` containers, and changing the blue border from being on the right of the section headers to being on the bottom. Most changes were made by changing the `flex-direction` from row to column.